### PR TITLE
Fix return type mismatch in mt:__index(i)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -38,7 +38,7 @@ end
 --- Overloads `[]` operator. It's possible to access individual chars with this operator. Index could be negative. In
 --- that case the counting will start from the end.
 --- @param i number Index at which retrieve a char.
---- @return string ch Single character at specified index. Nil if the index is larger than length of the string.
+--- @return string|nil ch Single character at specified index. Nil if the index is larger than length of the string.
 function mt:__index(i)
 	if string[i] then
 		return string[i]


### PR DESCRIPTION
This pull request removed the *Lua Diagnostics.(return-type-mismatch)* issue in `function mt:__index(i)`

> Annotations specify that return value #1 has a type of `string`, returning value of type `nil` here instead.
> - `nil` cannot match `string`
> - Type `nil` cannot match `string`

It results from line 48:

```lua
return #rs > 0 and rs or nil
```

and is addressed by adding ```|nil``` to the LuaDoc in line 41:

```lua
--- @return string|nil ch Single character at specified index. Nil if the index is larger than length of the string.
```